### PR TITLE
Use workspace as working directory for tests

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/MsTestBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/MsTestBuilder.java
@@ -177,7 +177,7 @@ public class MsTestBuilder extends Builder {
         }
 
         try {
-            int r = launcher.launch().cmds(args).envs(env).stdout(listener).pwd(build.getModuleRoot()).join();
+            int r = launcher.launch().cmds(args).envs(env).stdout(listener).pwd(build.getWorkspace()).join();
             return r == 0;
         } catch (IOException e) {
             Util.displayIOException(e, listener);


### PR DESCRIPTION
When using multiple modules for a job, plugin fails to delete existing results file (.trx) prior to running tests. Delete uses filename relative to workspace root, while mstest.exe uses filename relative to module directory.

This change should not affect configurations where local module directory is not defined or absolute paths are used.
