### PR TITLE
update documentation to ask for MSTest instead of MSBuild

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/MsTestInstallation/help-home.html
+++ b/src/main/resources/org/jenkinsci/plugins/MsTestInstallation/help-home.html
@@ -1,7 +1,7 @@
 <div>
     <p>
-        Specify the path to your msbuild executable. This will default to 'msbuild.exe'. It
-        is usually located at C:\WINDOWS\Microsoft.NET\Framework\[version]\MSBuild.exe.
+        Specify the path to your mstest executable. This will default to 'mstest.exe'. It
+        is usually located at C:\Program Files (x86)\Microsoft Visual Studio [version]\Common7\IDE\MSTest.exe
     </p>
 </div>
 <div>


### PR DESCRIPTION
The path to MSTest need to be defined instead of MSBuild
