### PR TITLE
Bugfix/tokenization of newlines fix [JENKINS-28869]

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/MsTestBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/MsTestBuilder.java
@@ -172,7 +172,8 @@ public class MsTestBuilder extends Builder {
         }
 
         // Add test containers to command line
-        StringTokenizer testFilesToknzr = new StringTokenizer(testFiles, "\r\n");
+        String macroReplacedTestFiles = Util.replaceMacro(testFiles, env);//Required to handle newlines properly
+        StringTokenizer testFilesToknzr = new StringTokenizer(macroReplacedTestFiles, "\r\n");
         while (testFilesToknzr.hasMoreTokens()) {
             String testFile = testFilesToknzr.nextToken();
             testFile = Util.replaceMacro(testFile, env);

--- a/src/main/java/org/jenkinsci/plugins/MsTestBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/MsTestBuilder.java
@@ -172,7 +172,7 @@ public class MsTestBuilder extends Builder {
         }
 
         // Add test containers to command line
-        String macroReplacedTestFiles = Util.replaceMacro(testFiles, env);//Required to handle newlines properly
+        String macroReplacedTestFiles = Util.replaceMacro(testFiles, env);// Required to handle newlines properly
         StringTokenizer testFilesToknzr = new StringTokenizer(macroReplacedTestFiles, "\r\n");
         while (testFilesToknzr.hasMoreTokens()) {
             String testFile = testFilesToknzr.nextToken();


### PR DESCRIPTION
Fix for problems with newlines in multiple testfiles taken from peroperties file as env. variable.
In this case only the first testfile was parsed correct and all other discarded.
