### PR TITLE
Handling spaces

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/MsTestBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/MsTestBuilder.java
@@ -204,15 +204,15 @@ public class MsTestBuilder extends Builder {
 
             if (testFile != null) {
             	File tcFile = new File(testFile);
-				if (tcFile.isAbsolute()) {
-					if (tcFile.isFile() && tcFile.exists()) {
-						testContainers.add(testFile);
-					}
+		if (tcFile.isAbsolute()) {
+			if (tcFile.isFile() && tcFile.exists()) {
+				testContainers.add(testFile);
+			}
             	} else {
-					for (FilePath tcFilePath : workspace.list(testFile)) {
-						// TODO make path relative to workspace to reduce length of command line (see windows max size)
-	            		testContainers.add(tcFilePath.getRemote());
-					}
+			for (FilePath tcFilePath : workspace.list(testFile)) {
+				// TODO make path relative to workspace to reduce length of command line (see windows max size)
+				testContainers.add(tcFilePath.getRemote());
+			}
             	}
             }
         }
@@ -223,7 +223,7 @@ public class MsTestBuilder extends Builder {
         }
 
         for (String testContainer : testContainers) {
-        	args.add("/testcontainer:" + testContainer);
+        	args.add("/testcontainer:" + "\"" + testContainer + "\"");
         }
 
         try {

--- a/src/main/java/org/jenkinsci/plugins/MsTestBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/MsTestBuilder.java
@@ -180,7 +180,7 @@ public class MsTestBuilder extends Builder {
         if (categories != null) {
         	// If filter consists of a single category such as /category:group1, do not have to enclose the filter in quotation marks.
         	// However, if filter references more than one category such as /category:"group1&group2" then the filter has to be enclosed in quotation marks.
-        	boolean quotationMarks = categories.contains("&") || categories.contains("!") || categories.contains("|");
+        	boolean quotationMarks = categories.contains("&") || categories.contains("!") || categories.contains("|") || categories.contains(" ");
        		args.add("/category:" + (quotationMarks ? "\"" : "") + categories + (quotationMarks ? "\"" : ""));
         }
 


### PR DESCRIPTION
I started using this plugin yesterday and immediately ran into issues.

For one, my unit tests have a category of "Unit Test", with a space. I changed your code to include quotes around categories if a space is present as well.

Jenkins on Windows usually gets installed under "Program Files (x86)". The workspace by default appears under that folder as well. Since there are spaces, the test container path needs to be quoted. I changed the code to simply wrap the path in quotes all the time. You might want to change it to only wrap in quotes if a space is present, not sure.
