### PR TITLE
[JENKINS-34392] Upgrade to 2.7 parent pom.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,7 @@ target/
 work/
 pom.xml.releaseBackup
 release.properties
+
+.settings
+.project
+.classpath

--- a/pom.xml
+++ b/pom.xml
@@ -4,10 +4,9 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>1.447</version><!-- which version of Jenkins is this plugin built against? -->
+        <version>2.7</version><!-- which version of Jenkins is this plugin built against? -->
     </parent>
 
-    <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>mstestrunner</artifactId>
     <version>1.2.1-SNAPSHOT</version>
     <packaging>hpi</packaging>
@@ -21,6 +20,11 @@
             <email>ido.ran@gmail.com</email>
         </developer>
     </developers>
+  
+    <properties>
+      <jenkins.version>1.580.1</jenkins.version>
+      <java.level>6</java.level>
+    </properties>
   
     <scm>
         <connection>scm:git:git://github.com/jenkinsci/mstestrunner-plugin.git</connection>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>2.7</version><!-- which version of Jenkins is this plugin built against? -->
+        <version>2.7</version>
     </parent>
 
     <artifactId>mstestrunner</artifactId>

--- a/src/main/java/org/jenkinsci/plugins/MsTestBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/MsTestBuilder.java
@@ -8,9 +8,7 @@ import hudson.Launcher;
 import hudson.Util;
 import hudson.model.BuildListener;
 import hudson.model.AbstractBuild;
-import hudson.model.Computer;
 import hudson.model.Descriptor;
-import hudson.model.Node;
 import hudson.model.AbstractProject;
 import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.Builder;
@@ -114,12 +112,6 @@ public class MsTestBuilder extends Builder {
             args.add(execName);
         } else {
             EnvVars env = build.getEnvironment(listener);
-            Node node = Computer.currentComputer().getNode();
-            if (node == null) {
-                listener.fatalError("Configuration has changed and node has been removed.");
-                return false;
-            }
-            installation = installation.forNode(node, listener);
             installation = installation.forEnvironment(env);
             String pathToMsTest = installation.getHome();
             FilePath exec = new FilePath(launcher.getChannel(), pathToMsTest);

--- a/src/main/java/org/jenkinsci/plugins/MsTestBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/MsTestBuilder.java
@@ -10,7 +10,7 @@ import hudson.model.BuildListener;
 import hudson.model.AbstractBuild;
 import hudson.model.Computer;
 import hudson.model.Descriptor;
-import hudson.model.AbstractBuild;
+import hudson.model.Node;
 import hudson.model.AbstractProject;
 import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.Builder;
@@ -114,7 +114,12 @@ public class MsTestBuilder extends Builder {
             args.add(execName);
         } else {
             EnvVars env = build.getEnvironment(listener);
-            installation = installation.forNode(Computer.currentComputer().getNode(), listener);
+            Node node = Computer.currentComputer().getNode();
+            if (node == null) {
+                listener.fatalError("Configuration has changed and node has been removed.");
+                return false;
+            }
+            installation = installation.forNode(node, listener);
             installation = installation.forEnvironment(env);
             String pathToMsTest = installation.getHome();
             FilePath exec = new FilePath(launcher.getChannel(), pathToMsTest);
@@ -269,7 +274,7 @@ public class MsTestBuilder extends Builder {
         }
 
         public MsTestInstallation[] getInstallations() {
-            return installations;
+            return Arrays.copyOf(installations, installations.length);
         }
 
         public void setInstallations(MsTestInstallation... antInstallations) {

--- a/src/main/java/org/jenkinsci/plugins/MsTestBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/MsTestBuilder.java
@@ -7,8 +7,10 @@ import hudson.FilePath;
 import hudson.Launcher;
 import hudson.Util;
 import hudson.model.BuildListener;
+import hudson.model.Computer;
 import hudson.model.AbstractBuild;
 import hudson.model.Descriptor;
+import hudson.model.Node;
 import hudson.model.AbstractProject;
 import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.Builder;
@@ -112,6 +114,12 @@ public class MsTestBuilder extends Builder {
             args.add(execName);
         } else {
             EnvVars env = build.getEnvironment(listener);
+            Node node = Computer.currentComputer().getNode();
+            if (node == null) {
+                listener.fatalError("Configuration has changed and node has been removed.");
+                return false;
+            }
+            installation = installation.forNode(node, listener);
             installation = installation.forEnvironment(env);
             String pathToMsTest = installation.getHome();
             FilePath exec = new FilePath(launcher.getChannel(), pathToMsTest);

--- a/src/main/java/org/jenkinsci/plugins/MsTestInstallation.java
+++ b/src/main/java/org/jenkinsci/plugins/MsTestInstallation.java
@@ -19,6 +19,8 @@ import java.io.IOException;
  */
 public final class MsTestInstallation extends ToolInstallation implements NodeSpecific<MsTestInstallation>, EnvironmentSpecific<MsTestInstallation> {
 
+    private static final long serialVersionUID = -2469009525603494417L;
+
     @SuppressWarnings("unused")
     /**
      * Backward compatibility

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <div>
     This plugin run MSTest command line tool to execute unit tests for .NET projects.
 </div>

--- a/src/main/resources/org/jenkinsci/plugins/MsTestBuilder/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/MsTestBuilder/config.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
          xmlns:t="/lib/hudson" xmlns:f="/lib/form">
 

--- a/src/main/resources/org/jenkinsci/plugins/MsTestInstallation/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/MsTestInstallation/config.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <f:entry title="${%Name}" field="name">
     <f:textbox />

--- a/src/test/java/org/jenkinsci/plugins/MsTestRunnerTest.java
+++ b/src/test/java/org/jenkinsci/plugins/MsTestRunnerTest.java
@@ -1,0 +1,134 @@
+package org.jenkinsci.plugins;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.util.concurrent.ExecutionException;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import hudson.Util;
+import hudson.model.FreeStyleBuild;
+import hudson.model.FreeStyleProject;
+import hudson.model.Result;
+import hudson.util.jna.GNUCLibrary;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+public class MsTestRunnerTest {
+
+    private static final String MS_TEST_INSTALLATION = "MSTestInstallation";
+    
+    private static final String SUCCESS_MESSAGE = "Running MsTest and succeeds";
+    private static final String FAILURE_MESSAGE = "Running MsTest and fails";
+
+    @Rule
+    public JenkinsRule r = new JenkinsRule();
+
+    @Test
+    public void runTestsBasic() throws URISyntaxException, IOException, InterruptedException, ExecutionException {
+        // Configure mocked MsTest tool that will not fail
+        mockMSTestInstallation(false);
+        FreeStyleProject p = createFreeStyleProjectWithMsTest("", "", false);
+        FreeStyleBuild build = p.scheduleBuild2(0).get();
+        
+        assertLogContains(SUCCESS_MESSAGE, build);
+        assertBuildStatus(Result.SUCCESS, build);
+    }
+
+    @Test
+    public void runTestsFail() throws InterruptedException, ExecutionException, URISyntaxException, IOException {
+        // Configure mocked MsTest tool that will fail
+        mockMSTestInstallation(true);
+        FreeStyleProject p = createFreeStyleProjectWithMsTest("", "", false);
+        FreeStyleBuild build = p.scheduleBuild2(0).get();
+        
+        assertLogContains(FAILURE_MESSAGE, build);
+        assertBuildStatus(Result.FAILURE, build);
+    }
+
+    @Test
+    public void ignoreFailingTests() throws InterruptedException, ExecutionException, URISyntaxException, IOException {
+        // Configure mocked MsTest tool that will fail
+        mockMSTestInstallation(true);
+        FreeStyleProject p = createFreeStyleProjectWithMsTest("", "", true);
+        FreeStyleBuild build = p.scheduleBuild2(0).get();
+        
+        assertLogContains(FAILURE_MESSAGE, build);
+        assertBuildStatus(Result.SUCCESS, build);
+    }
+    
+    @Test
+    public void runTestsWithCategories() throws URISyntaxException, IOException, InterruptedException, ExecutionException {
+        String category = "somecategory";
+        // Configure mocked MsTest tool that will not fail
+        mockMSTestInstallation(false);
+        FreeStyleProject p = createFreeStyleProjectWithMsTest(category, "", true);
+        FreeStyleBuild build = p.scheduleBuild2(0).get();
+        
+        assertLogContains(SUCCESS_MESSAGE, build);
+        assertLogContains("/category:" + category, build);
+        assertBuildStatus(Result.SUCCESS, build);
+    }
+
+    @Test
+    public void runTestsWithCmdArguments() throws URISyntaxException, IOException, InterruptedException, ExecutionException {
+        String cmdArg = "/testsettings:Local.Testsettings";
+        // Configure mocked MsTest tool that will not fail
+        mockMSTestInstallation(false);
+        FreeStyleProject p = createFreeStyleProjectWithMsTest("", cmdArg, true);
+        FreeStyleBuild build = p.scheduleBuild2(0).get();
+        
+        assertLogContains(SUCCESS_MESSAGE, build);
+        assertLogContains(cmdArg, build);
+        assertBuildStatus(Result.SUCCESS, build);
+    }
+
+    /**
+     * Configures the MSTest installation.
+     * 
+     * @param failingInstallation. If true, the use of MsTest will make the build fail.
+     * @return
+     * @throws URISyntaxException
+     */
+    private MsTestInstallation mockMSTestInstallation(boolean failingInstallation) throws URISyntaxException {
+        // Get appropriate installation file depending on parameter
+        String home = failingInstallation ? getClass().getResource("mstest/tool/mstest-fail").toURI().getPath()
+                                          : getClass().getResource("mstest/tool/mstest").toURI().getPath();
+        // Execution permissions for the tool
+        GNUCLibrary.LIBC.chmod(home, 0755);
+        // Configure installation
+        MsTestInstallation msTestInstallation = new MsTestInstallation(MS_TEST_INSTALLATION, home, null, false);
+        r.jenkins.getDescriptorByType(MsTestInstallation.DescriptorImpl.class).setInstallations(msTestInstallation);
+        return msTestInstallation;
+    }
+    
+    /**
+     * Creates a FreeStyleProject with a MSTestRunner build step.
+     * 
+     * @param categories the test categories to run
+     * @param cmdLineArgs the cmd line arguments to use when running MsTest
+     * @param ignoreFailingTests whether to ignore failing tests or not
+     * @return the FreeStyleProject
+     * @throws URISyntaxException
+     * @throws IOException
+     */
+    private FreeStyleProject createFreeStyleProjectWithMsTest(String categories, String cmdLineArgs, boolean ignoreFailingTests) throws URISyntaxException, IOException {
+        String msTestFiles = getClass().getResource("mstest/testfile").toURI().getPath();
+        FreeStyleProject p = r.jenkins.createProject(FreeStyleProject.class, "MSTestProject");
+        p.getBuildersList().add(new MsTestBuilder(MS_TEST_INSTALLATION, msTestFiles, categories, "resultFile", cmdLineArgs, ignoreFailingTests));
+        return p;
+    }
+    
+    private void assertLogContains(String text, FreeStyleBuild build) throws IOException {
+        String log = Util.loadFile(build.getLogFile(), build.getCharset());
+        assertTrue(log.contains(text));
+    }
+
+    private void assertBuildStatus(Result expectedStatus, FreeStyleBuild build) {
+        assertThat(build.getResult(), equalTo(expectedStatus));
+    }
+}

--- a/src/test/resources/org/jenkinsci/plugins/mstest/testfile
+++ b/src/test/resources/org/jenkinsci/plugins/mstest/testfile
@@ -1,0 +1,2 @@
+Content not relevant.
+Just need the file to be present for the test.

--- a/src/test/resources/org/jenkinsci/plugins/mstest/tool/mstest
+++ b/src/test/resources/org/jenkinsci/plugins/mstest/tool/mstest
@@ -1,0 +1,1 @@
+echo "Running MsTest and succeeds"

--- a/src/test/resources/org/jenkinsci/plugins/mstest/tool/mstest-fail
+++ b/src/test/resources/org/jenkinsci/plugins/mstest/tool/mstest-fail
@@ -1,0 +1,2 @@
+echo "Running MsTest and fails"
+exit 1


### PR DESCRIPTION
Upgrade to 2.7 parent pom. Includes some improvements that can be found [here](https://github.com/jenkinsci/plugin-pom)

- [x] Upgrade to new parent pom (version 2.7)
- [x] Bump baseline to version `1.580.1` since the `1.447` brings in a banned dependency by the parent pom: `sisu-guice` which causes the `maven-enforcer-plugin` to break the build.
- [x] Fix findbugs issues
- [x] Fix tests
- [x] Add test suite with main use cases
- [x] Update .gitignore

@reviewbybees 