### PR TITLE
[JENKINS-30457] Relative paths to test files with dots failing.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/MsTestBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/MsTestBuilder.java
@@ -209,10 +209,16 @@ public class MsTestBuilder extends Builder {
 						testContainers.add(testFile);
 					}
             	} else {
-					for (FilePath tcFilePath : workspace.list(testFile)) {
-						// TODO make path relative to workspace to reduce length of command line (see windows max size)
-	            		testContainers.add(tcFilePath.getRemote());
-					}
+                    FilePath testFilePath = workspace.child(testFile);
+                    // JENKINS-30457. To support dot-segments and maintain backwards compatibility since it was supported up till 1.1.2
+                    if (testFilePath.exists()) {
+                        testContainers.add(testFilePath.getRemote());
+                    } else {
+                        for (FilePath tcFilePath : workspace.list(testFile)) {
+                            // TODO make path relative to workspace to reduce length of command line (see windows max size)
+                            testContainers.add(tcFilePath.getRemote());
+                        }
+                    }
             	}
             }
         }

--- a/src/main/resources/org/jenkinsci/plugins/MsTestBuilder/help-testFiles.html
+++ b/src/main/resources/org/jenkinsci/plugins/MsTestBuilder/help-testFiles.html
@@ -2,7 +2,8 @@
     <p>
         Specify the path to your MSTest compiled assemblies.<br />
         You can specify multiple test assemblies by separating them with new-line.<br />
-        You can use either relative path to the workspace or full path. Spaces in the path are allowed.
+        You can use either relative path to the workspace or full path. Spaces in the path are allowed.<br />
+        You can use Ant-style filters. i.e - foo/*, foo/**/bar.dll, foo/*.dll
     </p>
 </div>
 <div>


### PR DESCRIPTION
Fixes [JENKINS-30457](https://issues.jenkins-ci.org/browse/JENKINS-30457)

This [commit](https://github.com/jenkinsci/mstestrunner-plugin/commit/8b6692c2db87c5b127be82c8a3a08996d06b5da8) caused that paths to files such as `.\{somepath}` started failing.

This PR:

- [x] Keeps the functionality that the commit added and allows dot-segments paths to maintain backwards compatibility.
- [x] Adds documentation on the feature added by the commit mentioned above

@reviewbybees 