### PR TITLE
[JENKINS-34378] Validation for the test result filename field.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/MsTestBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/MsTestBuilder.java
@@ -15,6 +15,7 @@ import hudson.model.AbstractProject;
 import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.Builder;
 import hudson.tools.ToolInstallation;
+import hudson.util.FormValidation;
 
 import java.io.File;
 import java.io.IOException;
@@ -25,7 +26,9 @@ import java.util.List;
 import java.util.Set;
 import java.util.StringTokenizer;
 
+import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.QueryParameter;
 
 /**
  * @author Ido Ran
@@ -282,6 +285,13 @@ public class MsTestBuilder extends Builder {
          */
         public MsTestInstallation.DescriptorImpl getToolDescriptor() {
             return ToolInstallation.all().get(MsTestInstallation.DescriptorImpl.class);
+        }
+        
+        public FormValidation doCheckResultFile(@QueryParameter String value) {
+            if (StringUtils.isBlank(value)) {
+                return FormValidation.warning("Result File Name must be provided.");
+            }
+            return FormValidation.ok();
         }
     }
 }


### PR DESCRIPTION
[JENKINS-34378](https://issues.jenkins-ci.org/browse/JENKINS-34378)

There was no validation for the test result filename field. However if it is not provided, the build will [fail](https://github.com/jenkinsci/mstestrunner-plugin/blob/master/src/main/java/org/jenkinsci/plugins/MsTestBuilder.java#L139). For that reason, it would be convenient to have basic validation for it.

@reviewbybees 