### PR TITLE
Add option to not fail the build if no test files are found

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,5 @@ release.properties
 .settings
 .project
 .classpath
+/.idea/
+*.iml

--- a/src/main/java/org/jenkinsci/plugins/MsTestBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/MsTestBuilder.java
@@ -44,6 +44,7 @@ public class MsTestBuilder extends Builder {
     private final String resultFile;
     private final String cmdLineArgs;
     private final boolean continueOnFail;
+    private final boolean failIfNoTests;
 
     /**
      * When this builder is created in the project configuration step,
@@ -52,16 +53,18 @@ public class MsTestBuilder extends Builder {
      * @param msTestName The MSTest logical name
      * @param testFiles The path of the test files
      * @param cmdLineArgs Whitespace separated list of command line arguments
+     * @param failIfNoTests
      */
     @DataBoundConstructor
     @SuppressWarnings("unused")
-    public MsTestBuilder(String msTestName, String testFiles, String categories, String resultFile, String cmdLineArgs, boolean continueOnFail) {
+    public MsTestBuilder(String msTestName, String testFiles, String categories, String resultFile, String cmdLineArgs, boolean continueOnFail, boolean failIfNoTests) {
         this.msTestName = msTestName;
         this.testFiles = testFiles;
         this.categories = categories;
         this.resultFile = resultFile;
         this.cmdLineArgs = cmdLineArgs;
         this.continueOnFail = continueOnFail;
+        this.failIfNoTests = failIfNoTests;
     }
 
     @SuppressWarnings("unused")
@@ -92,6 +95,11 @@ public class MsTestBuilder extends Builder {
     @SuppressWarnings("unused")
     public boolean getcontinueOnFail() {
         return continueOnFail;
+    }
+
+    @SuppressWarnings("unused")
+    public boolean getFailIfNoTests() {
+        return failIfNoTests;
     }
 
     public MsTestInstallation getMsTest() {
@@ -232,8 +240,14 @@ public class MsTestBuilder extends Builder {
         }
         // nothing of include rule has match files in workspace folder
         if (testContainers.isEmpty()) {
-        	listener.fatalError("No test files was found");
-        	return false;
+            if (failIfNoTests) {
+                listener.fatalError("No test files was found");
+                return false;
+            }
+            else {
+                listener.getLogger().println("No test files was found, but the configuration says we should continue with the build anyway.");
+                return true;
+            }
         }
 
         for (String testContainer : testContainers) {

--- a/src/main/resources/org/jenkinsci/plugins/MsTestBuilder/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/MsTestBuilder/config.jelly
@@ -14,6 +14,9 @@
     <f:entry title="Test Files" field="testFiles">
         <f:expandableTextbox name="MsTestBuilder.testFiles" value="${instance.testFiles}"/>
     </f:entry>
+    <f:entry title="${%Fail if no tests}" field="failIfNoTests">
+      <f:checkbox checked="true" />
+    </f:entry>
     <f:entry title="Test Categories" field="categories">
         <f:textbox name="MsTestBuilder.categories" value="${instance.categories}" />
     </f:entry>

--- a/src/main/resources/org/jenkinsci/plugins/MsTestBuilder/help-failIfNoTests.html
+++ b/src/main/resources/org/jenkinsci/plugins/MsTestBuilder/help-failIfNoTests.html
@@ -1,0 +1,5 @@
+<div>
+    <p>
+        Specify if the build should fail if no test files are found.
+    </p>
+</div>

--- a/src/test/java/org/jenkinsci/plugins/MsTestRunnerTest.java
+++ b/src/test/java/org/jenkinsci/plugins/MsTestRunnerTest.java
@@ -32,7 +32,7 @@ public class MsTestRunnerTest {
     public void runTestsBasic() throws URISyntaxException, IOException, InterruptedException, ExecutionException {
         // Configure mocked MsTest tool that will not fail
         mockMSTestInstallation(false);
-        FreeStyleProject p = createFreeStyleProjectWithMsTest("", "", false);
+        FreeStyleProject p = createFreeStyleProjectWithMsTest("", "", false, true);
         FreeStyleBuild build = p.scheduleBuild2(0).get();
         
         assertLogContains(SUCCESS_MESSAGE, build);
@@ -43,7 +43,7 @@ public class MsTestRunnerTest {
     public void runTestsFail() throws InterruptedException, ExecutionException, URISyntaxException, IOException {
         // Configure mocked MsTest tool that will fail
         mockMSTestInstallation(true);
-        FreeStyleProject p = createFreeStyleProjectWithMsTest("", "", false);
+        FreeStyleProject p = createFreeStyleProjectWithMsTest("", "", false, true);
         FreeStyleBuild build = p.scheduleBuild2(0).get();
         
         assertLogContains(FAILURE_MESSAGE, build);
@@ -54,7 +54,7 @@ public class MsTestRunnerTest {
     public void ignoreFailingTests() throws InterruptedException, ExecutionException, URISyntaxException, IOException {
         // Configure mocked MsTest tool that will fail
         mockMSTestInstallation(true);
-        FreeStyleProject p = createFreeStyleProjectWithMsTest("", "", true);
+        FreeStyleProject p = createFreeStyleProjectWithMsTest("", "", true, true);
         FreeStyleBuild build = p.scheduleBuild2(0).get();
         
         assertLogContains(FAILURE_MESSAGE, build);
@@ -66,7 +66,7 @@ public class MsTestRunnerTest {
         String category = "somecategory";
         // Configure mocked MsTest tool that will not fail
         mockMSTestInstallation(false);
-        FreeStyleProject p = createFreeStyleProjectWithMsTest(category, "", true);
+        FreeStyleProject p = createFreeStyleProjectWithMsTest(category, "", true, true);
         FreeStyleBuild build = p.scheduleBuild2(0).get();
         
         assertLogContains(SUCCESS_MESSAGE, build);
@@ -79,7 +79,7 @@ public class MsTestRunnerTest {
         String cmdArg = "/testsettings:Local.Testsettings";
         // Configure mocked MsTest tool that will not fail
         mockMSTestInstallation(false);
-        FreeStyleProject p = createFreeStyleProjectWithMsTest("", cmdArg, true);
+        FreeStyleProject p = createFreeStyleProjectWithMsTest("", cmdArg, true, true);
         FreeStyleBuild build = p.scheduleBuild2(0).get();
         
         assertLogContains(SUCCESS_MESSAGE, build);
@@ -112,14 +112,15 @@ public class MsTestRunnerTest {
      * @param categories the test categories to run
      * @param cmdLineArgs the cmd line arguments to use when running MsTest
      * @param ignoreFailingTests whether to ignore failing tests or not
+     * @param failIfNoTests whether to fail the build if no test files are found
      * @return the FreeStyleProject
      * @throws URISyntaxException
      * @throws IOException
      */
-    private FreeStyleProject createFreeStyleProjectWithMsTest(String categories, String cmdLineArgs, boolean ignoreFailingTests) throws URISyntaxException, IOException {
+    private FreeStyleProject createFreeStyleProjectWithMsTest(String categories, String cmdLineArgs, boolean ignoreFailingTests, boolean failIfNoTests) throws URISyntaxException, IOException {
         String msTestFiles = getClass().getResource("mstest/testfile").toURI().getPath();
         FreeStyleProject p = r.jenkins.createProject(FreeStyleProject.class, "MSTestProject");
-        p.getBuildersList().add(new MsTestBuilder(MS_TEST_INSTALLATION, msTestFiles, categories, "resultFile", cmdLineArgs, ignoreFailingTests));
+        p.getBuildersList().add(new MsTestBuilder(MS_TEST_INSTALLATION, msTestFiles, categories, "resultFile", cmdLineArgs, ignoreFailingTests, failIfNoTests));
         return p;
     }
     


### PR DESCRIPTION
We have a scenario where a large number of .NET Jenkins jobs are created from a template job. The template runs tests using MSTest and has the full configuration for this. Some of the projects however do not (yet) have tests, and we want an easy way do disable the running of test until tests have been added to those projects.
For this reason we have added an option to not fail the build if no test files are found. The default behaviour, of failing the build if no test files are found, is preserved. A new job configuration checkbox (defaults to checked) named "Fail if no tests" has been added, and can be un-checked for jobs that do not (yet) have any tests.