### PR TITLE
Make sure the current configuration is read into the UI.

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/MsTestBuilder/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/MsTestBuilder/config.jelly
@@ -15,7 +15,7 @@
         <f:expandableTextbox name="MsTestBuilder.testFiles" value="${instance.testFiles}"/>
     </f:entry>
     <f:entry title="${%Fail if no tests}" field="failIfNoTests">
-      <f:checkbox checked="true" />
+      <f:checkbox checked="${instance.failIfNoTests}" />
     </f:entry>
     <f:entry title="Test Categories" field="categories">
         <f:textbox name="MsTestBuilder.categories" value="${instance.categories}" />


### PR DESCRIPTION
We just discovered that the changes that we made to the Jelly file was not correct. It always defaulted to having the checkbox checked, regardless of what the actual configuration was. The result was that if the checkbox was unchecked and someone configured something else in the job the configuration for the checkbox was changed as well.